### PR TITLE
Fix GitHub workflow typo

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -20,6 +20,7 @@ on:
     - main
 
 jobs:
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:
@@ -28,8 +29,6 @@ jobs:
       with:
         python-version: "3.13"
     - uses: pre-commit/action@v3.0.1
-
-jobs:
 
   pre-commit:
     name: Pre-commit


### PR DESCRIPTION
The `jobs` section is duplicated.