### PR TITLE
Add parameters to templates

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -554,6 +554,13 @@
         "template_id": {
           "type": "string",
           "description": "Reference to the cluster template.\n\nThis is mandatory, and must be the value of the `id` field of one of the cluster templates."
+        },
+        "template_parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "Values of the template parameters.\n\nWhen using the HTTP+JSON version of the API the values must be represented as documented in the (ProtoJSON format\ndocument)[https://protobuf.dev/programming-guides/json]. For example, if the template has a `number_of_nodes`\nparameter of integer type, the complete order should be represented like this:\n\n```json\n{\n  \"template_id\": \"123\",\n  \"template_parameters\": {\n    \"number_of_nodes\": {\n      \"@type\": \"type.googleapis.com/google.protobuf.Int32Value\",\n      \"value\": 42\n    }\n  }\n}\n```\n\nThe possible values of the `@type` are the same as those used by the `type_url` field of the `Any` type:\n\n| Type                           | Value                                             |\n|--------------------------------|---------------------------------------------------|\n| Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |\n| Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |\n| Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |\n| Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |\n| Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |\n| String                         | `type.googleapis.com/google.protobuf.StringValue` |\n| Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |\n| Duration                       | `type.googleapis.com/google.protobuf.Duration`    |\n| Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |\n| Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |"
         }
       },
       "description": "Contains the details that the user provides to request the provisioning of the cluster."
@@ -696,9 +703,47 @@
         "description": {
           "type": "string",
           "description": "Human friendly long description of the template, using Markdown format."
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ClusterTemplateParameterDefinition"
+          },
+          "description": "Definitions of the parameters that can be used to customize the template.\n\nNote that these are only the *definitions* of the parameters, not the actual values. The actual values are in the\n`spec.template_parameters` field of the cluster order."
         }
       },
       "description": "A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these\ntemplates: the system provides a collection of them, and the user chooses one."
+    },
+    "v1ClusterTemplateParameterDefinition": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the parameter.\n\nThis is the name that should be used in the `template_parameters` field of the order to assign a value to the\nparameter."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human friendly short description of the parameter, only a few words, suitable for displaying in one single line on\na UI or CLI."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human friendly description of the parameter, using Markdown format."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Indicates if this parameter is required or optional.\n\nValues for required parameters must be included when sending the order, otherwise it will be rejected.\n\nNote that there may be other dependencies between parameters which may cause a order to be rejected. For example,\nthe allowed values of a parameter may depend on the value of another parameter. That kind of information will be in\nthe `description` field."
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the parameter.\n\nThe possible values are the same as those used by the `type_url` field of the `Any` type:\n\n| Type                           | Value                                             |\n|--------------------------------|---------------------------------------------------|\n| Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |\n| Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |\n| Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |\n| Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |\n| Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |\n| String                         | `type.googleapis.com/google.protobuf.StringValue` |\n| Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |\n| Duration                       | `type.googleapis.com/google.protobuf.Duration`    |\n| Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |\n| Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |\n\nWhen using the HTTP+JSON version of the API the value provided in the `template_parameters` field of the order\nmust be represented as documented in the (ProtoJSON format document)[https://protobuf.dev/programming-guides/json]."
+        },
+        "default": {
+          "$ref": "#/definitions/protobufAny",
+          "description": "Default value for optional parameters."
+        }
+      },
+      "description": "Contains type and documentation of a template parameter."
     },
     "v1ClusterTemplatesGetResponse": {
       "type": "object",

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -748,6 +748,43 @@ components:
             Reference to the cluster template.
 
             This is mandatory, and must be the value of the `id` field of one of the cluster templates.
+        template_parameters:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/protobufAny"
+          description: |-
+            Values of the template parameters.
+
+            When using the HTTP+JSON version of the API the values must be represented as documented in the (ProtoJSON format
+            document)[https://protobuf.dev/programming-guides/json]. For example, if the template has a `number_of_nodes`
+            parameter of integer type, the complete order should be represented like this:
+
+            ```json
+            {
+              "template_id": "123",
+              "template_parameters": {
+                "number_of_nodes": {
+                  "@type": "type.googleapis.com/google.protobuf.Int32Value",
+                  "value": 42
+                }
+              }
+            }
+            ```
+
+            The possible values of the `@type` are the same as those used by the `type_url` field of the `Any` type:
+
+            | Type                           | Value                                             |
+            |--------------------------------|---------------------------------------------------|
+            | Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |
+            | Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |
+            | Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |
+            | Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |
+            | Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |
+            | String                         | `type.googleapis.com/google.protobuf.StringValue` |
+            | Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |
+            | Duration                       | `type.googleapis.com/google.protobuf.Duration`    |
+            | Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |
+            | Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |
       description: Contains the details that the user provides to request the provisioning
         of the cluster.
     v1ClusterOrderState:
@@ -969,9 +1006,72 @@ components:
           type: string
           description: "Human friendly long description of the template, using Markdown\
             \ format."
+        parameters:
+          type: array
+          description: |-
+            Definitions of the parameters that can be used to customize the template.
+
+            Note that these are only the *definitions* of the parameters, not the actual values. The actual values are in the
+            `spec.template_parameters` field of the cluster order.
+          items:
+            $ref: "#/components/schemas/v1ClusterTemplateParameterDefinition"
       description: |-
         A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these
         templates: the system provides a collection of them, and the user chooses one.
+    v1ClusterTemplateParameterDefinition:
+      type: object
+      properties:
+        name:
+          type: string
+          description: |-
+            Name of the parameter.
+
+            This is the name that should be used in the `template_parameters` field of the order to assign a value to the
+            parameter.
+        title:
+          type: string
+          description: |-
+            Human friendly short description of the parameter, only a few words, suitable for displaying in one single line on
+            a UI or CLI.
+        description:
+          type: string
+          description: "Human friendly description of the parameter, using Markdown\
+            \ format."
+        required:
+          type: boolean
+          description: |-
+            Indicates if this parameter is required or optional.
+
+            Values for required parameters must be included when sending the order, otherwise it will be rejected.
+
+            Note that there may be other dependencies between parameters which may cause a order to be rejected. For example,
+            the allowed values of a parameter may depend on the value of another parameter. That kind of information will be in
+            the `description` field.
+        type:
+          type: string
+          description: |-
+            Type of the parameter.
+
+            The possible values are the same as those used by the `type_url` field of the `Any` type:
+
+            | Type                           | Value                                             |
+            |--------------------------------|---------------------------------------------------|
+            | Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |
+            | Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |
+            | Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |
+            | Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |
+            | Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |
+            | String                         | `type.googleapis.com/google.protobuf.StringValue` |
+            | Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |
+            | Duration                       | `type.googleapis.com/google.protobuf.Duration`    |
+            | Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |
+            | Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |
+
+            When using the HTTP+JSON version of the API the value provided in the `template_parameters` field of the order
+            must be represented as documented in the (ProtoJSON format document)[https://protobuf.dev/programming-guides/json].
+        default:
+          $ref: "#/components/schemas/protobufAny"
+      description: Contains type and documentation of a template parameter.
     v1ClusterTemplatesGetResponse:
       type: object
       properties:

--- a/proto/fulfillment/v1/cluster_order_type.proto
+++ b/proto/fulfillment/v1/cluster_order_type.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 package fulfillment.v1;
 
 import "fulfillment/v1/condition_status_type.proto";
+import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
 // Contains the details that the user provides to request the provisioning of a cluster, as well as the current status
@@ -35,7 +36,41 @@ message ClusterOrderSpec {
   // Reference to the cluster template.
   //
   // This is mandatory, and must be the value of the `id` field of one of the cluster templates.
-  string template_id = 2;
+  string template_id = 1;
+
+  // Values of the template parameters.
+  //
+  // When using the HTTP+JSON version of the API the values must be represented as documented in the (ProtoJSON format
+  // document)[https://protobuf.dev/programming-guides/json]. For example, if the template has a `number_of_nodes`
+  // parameter of integer type, the complete order should be represented like this:
+  //
+  // ```json
+  // {
+  //   "template_id": "123",
+  //   "template_parameters": {
+  //     "number_of_nodes": {
+  //       "@type": "type.googleapis.com/google.protobuf.Int32Value",
+  //       "value": 42
+  //     }
+  //   }
+  // }
+  // ```
+  //
+  // The possible values of the `@type` are the same as those used by the `type_url` field of the `Any` type:
+  //
+  // | Type                           | Value                                             |
+  // |--------------------------------|---------------------------------------------------|
+  // | Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |
+  // | Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |
+  // | Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |
+  // | Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |
+  // | Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |
+  // | String                         | `type.googleapis.com/google.protobuf.StringValue` |
+  // | Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |
+  // | Duration                       | `type.googleapis.com/google.protobuf.Duration`    |
+  // | Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |
+  // | Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |
+  map<string, google.protobuf.Any> template_parameters = 2;
 }
 
 // Contains the current status of the order.

--- a/proto/fulfillment/v1/cluster_template_type.proto
+++ b/proto/fulfillment/v1/cluster_template_type.proto
@@ -15,6 +15,8 @@ syntax = "proto3";
 
 package fulfillment.v1;
 
+import "google/protobuf/any.proto";
+
 // A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these
 // templates: the system provides a collection of them, and the user chooses one.
 message ClusterTemplate {
@@ -27,4 +29,59 @@ message ClusterTemplate {
 
   // Human friendly long description of the template, using Markdown format.
   string description = 3;
+
+  // Definitions of the parameters that can be used to customize the template.
+  //
+  // Note that these are only the *definitions* of the parameters, not the actual values. The actual values are in the
+  // `spec.template_parameters` field of the cluster order.
+  repeated ClusterTemplateParameterDefinition parameters = 4;
+}
+
+// Contains type and documentation of a template parameter.
+message ClusterTemplateParameterDefinition {
+  // Name of the parameter.
+  //
+  // This is the name that should be used in the `template_parameters` field of the order to assign a value to the
+  // parameter.
+  string name = 1;
+
+  // Human friendly short description of the parameter, only a few words, suitable for displaying in one single line on
+  // a UI or CLI.
+  string title = 2;
+
+  // Human friendly description of the parameter, using Markdown format.
+  string description = 3;
+
+  // Indicates if this parameter is required or optional.
+  //
+  // Values for required parameters must be included when sending the order, otherwise it will be rejected.
+  //
+  // Note that there may be other dependencies between parameters which may cause a order to be rejected. For example,
+  // the allowed values of a parameter may depend on the value of another parameter. That kind of information will be in
+  // the `description` field.
+  bool required = 4;
+
+  // Type of the parameter.
+  //
+  // The possible values are the same as those used by the `type_url` field of the `Any` type:
+  //
+  // | Type                           | Value                                             |
+  // |--------------------------------|---------------------------------------------------|
+  // | Boolean                        | `type.googleapis.com/google.protobuf.BoolValue`   |
+  // | Integer number, 32 bits        | `type.googleapis.com/google.protobuf.Int32Value`  |
+  // | Integer number, 64 bits        | `type.googleapis.com/google.protobuf.Int64Value`  |
+  // | Floating point number, 32 bits | `type.googleapis.com/google.protobuf.FloatValue`  |
+  // | Floating point number, 64 bits | `type.googleapis.com/google.protobuf.DoubleValue` |
+  // | String                         | `type.googleapis.com/google.protobuf.StringValue` |
+  // | Timestamp                      | `type.googleapis.com/google.protobuf.Timestamp`   |
+  // | Duration                       | `type.googleapis.com/google.protobuf.Duration`    |
+  // | Array of bytes                 | `type.googleapis.com/google.protobuf.BytesValue`  |
+  // | Any JSON value                 | `type.googleapis.com/google.protobuf.Value`       |
+  //
+  // When using the HTTP+JSON version of the API the value provided in the `template_parameters` field of the order
+  // must be represented as documented in the (ProtoJSON format document)[https://protobuf.dev/programming-guides/json].
+  string type = 5;
+
+  // Default value for optional parameters.
+  google.protobuf.Any default = 6;
 }


### PR DESCRIPTION
The names and types of the parameters will be included in the representation of the templates. For example, for a template with an optional `node_count` parameter the template will be represented like this (when converted to JSON):

```json
{
  "id": "123",
  "title": "my_template",
  "description": "My template is *nice*.",
  "required": false,
  "parameters": [
    {
      "name": "node_count",
      "title": "Number of nodes",
      "description": "The number of nodes of the cluster",
      "type": "type.googleapis.com/google.protobuf.Int32Value",
      "default": {
        "@type": "type.googleapis.com/google.protobuf.Int32Value",
        "value": 3
      }
    }
  ]
}
```

The values of the parameters will be supplied as part of the order. For example, to create a cluster with 42 nodes:

```json
{
  "order": {
    "spec": {
      "template_id": "123",
      "template_parameters": {
        "node_count": {
	  "@type": "type.googleapis.com/google.protobuf.Int32Value",
	  "value": 42
	}
      }
    }
  }
}
```

Related: https://github.com/innabox/fulfillment-api/issues/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced cluster template customization by introducing configurable parameter options.
  - Users can now supply custom values when placing orders, improving flexibility.
  - Clear definitions for parameter attributes (such as name, title, description, type, and default settings) ensure consistent and powerful template configuration.
  - New properties `template_parameters` and `parameters` added for better management of template definitions.
  - Introduced a new message for defining template parameter structures, enhancing clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->