### PR TITLE
Add endpoint to retrieve admin Kubeconfig

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -354,6 +354,38 @@
         ]
       }
     },
+    "/api/fulfillment/v1/clusters/{cluster_id}/kubeconfig": {
+      "get": {
+        "summary": "Returns the admin Kubeconfig of the cluster.",
+        "description": "This is intended for use with HTTP and returns the YAML text of the Kubeconfig directly using the content type\n`application/yaml`.\n\nbuf:lint:ignore RPC_RESPONSE_STANDARD_NAME",
+        "operationId": "Clusters_GetKubeconfigViaHttp",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiHttpBody"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Clusters"
+        ]
+      }
+    },
     "/api/fulfillment/v1/events": {
       "get": {
         "summary": "Watches events.",
@@ -404,6 +436,29 @@
     }
   },
   "definitions": {
+    "apiHttpBody": {
+      "type": "object",
+      "properties": {
+        "content_type": {
+          "type": "string",
+          "description": "The HTTP Content-Type header value specifying the content type of the body."
+        },
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "description": "The HTTP request/response body as raw binary."
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "Application specific response metadata. Must be set in the first response\nfor streaming APIs."
+        }
+      },
+      "description": "Message that represents an arbitrary HTTP body. It should only be used for\npayload formats that can't be represented as JSON, such as raw binary or\nan HTML page.\n\n\nThis message can be used both in streaming and non-streaming API methods in\nthe request as well as the response.\n\nIt can be used as a top-level request field, which is convenient if one\nwants to extract parameters from either the URL or HTTP template into the\nrequest fields and also want access to the raw HTTP body.\n\nExample:\n\n    message GetResourceRequest {\n      // A unique request id.\n      string request_id = 1;\n\n      // The raw HTTP body is bound to this field.\n      google.api.HttpBody http_body = 2;\n\n    }\n\n    service ResourceService {\n      rpc GetResource(GetResourceRequest)\n        returns (google.api.HttpBody);\n      rpc UpdateResource(google.api.HttpBody)\n        returns (google.protobuf.Empty);\n\n    }\n\nExample with streaming methods:\n\n    service CaldavService {\n      rpc GetCalendar(stream google.api.HttpBody)\n        returns (stream google.api.HttpBody);\n      rpc UpdateCalendar(stream google.api.HttpBody)\n        returns (stream google.api.HttpBody);\n\n    }\n\nUse of this type only changes how the request and response bodies are\nhandled, all other features will continue to work unchanged."
+    },
     "protobufAny": {
       "type": "object",
       "properties": {
@@ -617,6 +672,14 @@
             "$ref": "#/definitions/v1ClusterTemplate"
           },
           "description": "List of results."
+        }
+      }
+    },
+    "v1ClustersGetKubeconfigResponse": {
+      "type": "object",
+      "properties": {
+        "kubeconfig": {
+          "type": "string"
         }
       }
     },

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -379,6 +379,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/clusters/{cluster_id}/kubeconfig:
+    get:
+      tags:
+      - Clusters
+      summary: Returns the admin Kubeconfig of the cluster.
+      description: |-
+        This is intended for use with HTTP and returns the YAML text of the Kubeconfig directly using the content type
+        `application/yaml`.
+
+        buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+      operationId: Clusters_GetKubeconfigViaHttp
+      parameters:
+      - name: cluster_id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/apiHttpBody"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
   /api/fulfillment/v1/events:
     get:
       tags:
@@ -432,6 +464,69 @@ paths:
                 $ref: "#/components/schemas/rpcStatus"
 components:
   schemas:
+    apiHttpBody:
+      type: object
+      properties:
+        content_type:
+          type: string
+          description: The HTTP Content-Type header value specifying the content type
+            of the body.
+        data:
+          pattern: "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+          type: string
+          description: The HTTP request/response body as raw binary.
+          format: byte
+        extensions:
+          type: array
+          description: |-
+            Application specific response metadata. Must be set in the first response
+            for streaming APIs.
+          items:
+            $ref: "#/components/schemas/protobufAny"
+      description: |-
+        Message that represents an arbitrary HTTP body. It should only be used for
+        payload formats that can't be represented as JSON, such as raw binary or
+        an HTML page.
+
+
+        This message can be used both in streaming and non-streaming API methods in
+        the request as well as the response.
+
+        It can be used as a top-level request field, which is convenient if one
+        wants to extract parameters from either the URL or HTTP template into the
+        request fields and also want access to the raw HTTP body.
+
+        Example:
+
+            message GetResourceRequest {
+              // A unique request id.
+              string request_id = 1;
+
+              // The raw HTTP body is bound to this field.
+              google.api.HttpBody http_body = 2;
+
+            }
+
+            service ResourceService {
+              rpc GetResource(GetResourceRequest)
+                returns (google.api.HttpBody);
+              rpc UpdateResource(google.api.HttpBody)
+                returns (google.protobuf.Empty);
+
+            }
+
+        Example with streaming methods:
+
+            service CaldavService {
+              rpc GetCalendar(stream google.api.HttpBody)
+                returns (stream google.api.HttpBody);
+              rpc UpdateCalendar(stream google.api.HttpBody)
+                returns (stream google.api.HttpBody);
+
+            }
+
+        Use of this type only changes how the request and response bodies are
+        handled, all other features will continue to work unchanged.
     protobufAny:
       type: object
       properties:
@@ -733,6 +828,11 @@ components:
           description: List of results.
           items:
             $ref: "#/components/schemas/v1ClusterTemplate"
+    v1ClustersGetKubeconfigResponse:
+      type: object
+      properties:
+        kubeconfig:
+          type: string
     v1ClustersGetResponse:
       type: object
       properties:

--- a/proto/fulfillment/v1/clusters_service.proto
+++ b/proto/fulfillment/v1/clusters_service.proto
@@ -17,6 +17,7 @@ package fulfillment.v1;
 
 import "fulfillment/v1/cluster_type.proto";
 import "google/api/annotations.proto";
+import "google/api/httpbody.proto";
 
 message ClustersListRequest {
   // Index of the first result. If not specified the default value will be zero.
@@ -73,6 +74,18 @@ message ClustersGetResponse {
   Cluster cluster = 1;
 }
 
+message ClustersGetKubeconfigRequest {
+  string cluster_id = 1;
+}
+
+message ClustersGetKubeconfigResponse {
+  string kubeconfig = 1;
+}
+
+message ClustersGetKubeconfigViaHttpRequest {
+  string cluster_id = 1;
+}
+
 service Clusters {
   // Retrieves the list of clusters.
   rpc List(ClustersListRequest) returns (ClustersListResponse) {
@@ -82,5 +95,21 @@ service Clusters {
   // Retrieves the details of one specific cluster.
   rpc Get(ClustersGetRequest) returns (ClustersGetResponse) {
     option (google.api.http) = {get: "/api/fulfillment/v1/clusters/{cluster_id}"};
+  }
+
+  // Returns the admin Kubeconfig of the cluster.
+  //
+  // This intended for use with the gRPC protocol, and it isn't mapped to an HTTP endpoint. To retrieve the Kubeconfig
+  // via HTTP see the `ClustersGetKubeconfigViaHttp` method below.
+  rpc GetKubeconfig(ClustersGetKubeconfigRequest) returns (ClustersGetKubeconfigResponse) {}
+
+  // Returns the admin Kubeconfig of the cluster.
+  //
+  // This is intended for use with HTTP and returns the YAML text of the Kubeconfig directly using the content type
+  // `application/yaml`.
+  //
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc GetKubeconfigViaHttp(ClustersGetKubeconfigViaHttpRequest) returns (google.api.HttpBody) {
+    option (google.api.http) = {get: "/api/fulfillment/v1/clusters/{cluster_id}/kubeconfig"};
   }
 }


### PR DESCRIPTION
This patch adds two new methods to retrieve the admin Kubeconfig of a cluster: `GetKubeconfig` and `GetKubeconfigViaHttp`. The first is intended for use with gRPC only, and it isn't mapped to HTTP. The second is intended for use with HTTP only, and can be used like this:

    GET /api/fulfillment/v1/clusters/123/kubeconfig HTTP/1.1

    HTTP/1.1 200 OK
    Content-Type: application/yaml
    Content-Length: 21484

    apiVersion: v1
    clusters:
    - cluster:
    ...

References: https://github.com/innabox/fulfillment-api/issues/12

Note that this pull request also includes the patch from #18, will need to be rebased once that is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint that lets users retrieve the administrative Kubeconfig in YAML format for a specific cluster.
	- Enabled support for both HTTP and gRPC protocols to enhance integration.
	- Requires the submission of a valid cluster identifier to access the configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->