### PR TITLE
Add workflow to update site

### DIFF
--- a/.github/workflows/update-pages.yaml
+++ b/.github/workflows/update-pages.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# This workflow generates the OpenAPI specification and uploads it to the GitHub pages of the project.
+
+name: Update pages
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Checkout the source
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+        cache: 'pip'
+
+    - name: Install Python modules
+      run: |
+        pip install -r requirements.txt
+
+    - name: Install tools
+      run: |
+        export PATH="../.local/bin:${PATH}"
+        ./dev.py setup
+
+    - name: Generate the OpenAPI code
+      run: |
+        export PATH="../.local/bin:${PATH}"
+        ./dev.py generate
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: openapi
+
+  deploy:
+    name: Deploy artifacts
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+
+      - name: Deploy artifacts
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/dev/generate.py
+++ b/dev/generate.py
@@ -42,13 +42,12 @@ def openapi() -> None:
     # Remove previously generated files:
     project_dir = dirs.project()
     openapi_dir = project_dir / "openapi"
-    if openapi_dir.exists():
-        shutil.rmtree(openapi_dir)
-        openapi_dir.mkdir(parents=True)
     v2_dir = openapi_dir / "v2"
-    v2_dir.mkdir(parents=True)
+    if v2_dir.exists():
+        shutil.rmtree(v2_dir)
     v3_dir = openapi_dir / "v3"
-    v3_dir.mkdir(parents=True)
+    if v3_dir.exists():
+        shutil.rmtree(v3_dir)
 
     # Create a temporary directory for the downloaded files:
     tmp_dir = pathlib.Path(tempfile.mkdtemp())
@@ -71,6 +70,8 @@ def openapi() -> None:
             raise Exception(f"Expected exactly one generated OpenAPI file, but found {len(v2_tmp_files)}")
         v2_tmp_file = v2_tmp_files[0]
         v2_file = v2_dir / "openapi.json"
+        if not v2_dir.exists():
+            v2_dir.mkdir(parents=True)
         shutil.move(v2_tmp_file, v2_file)
 
         # Use the 'swagger-codegen-cli' tool to read the generated version 2 and write version 3:
@@ -92,6 +93,8 @@ def openapi() -> None:
             raise Exception(f"Expected exactly one generated OpenAPI file, but found {len(v3_tmp_files)}")
         v3_tmp_file = v3_tmp_files[0]
         v3_file = v3_dir / "openapi.yaml"
+        if not v3_dir.exists():
+            v3_dir.mkdir(parents=True)
         shutil.move(v3_tmp_file, v3_file)
     finally:
         shutil.rmtree(tmp_dir)

--- a/openapi/index.html
+++ b/openapi/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Fulfillment API" />
+  <title>Fulfillment API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+  window.onload = () => {
+    window.ui = SwaggerUIBundle({
+      url: "v3/openapi.yaml",
+      dom_id: "#swagger-ui",
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
This patch adds an new `update-pages` workflow that runs when changes and pushes to the main branch and publishes the generated OpenAPI, together with a SwaggerUI viewer to the GitHub page of the project. The result will be something like this (but using "innabox.github.io"):

![image](https://github.com/user-attachments/assets/8308d264-5abe-4913-aae4-169d3ee2766c)

Note that for this to work the GitHub pages option needs to be enabled in the settings of the project, and configured to use a workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow to build and deploy API documentation to GitHub Pages on updates.
  - Launched a new documentation page for the Fulfillment API featuring interactive Swagger UI.

- **Refactor**
  - Improved the file organization for generated API documentation by streamlining the management of required directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->