### PR TITLE
Add cluster node sets

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -24,6 +24,9 @@
     },
     {
       "name": "Clusters"
+    },
+    {
+      "name": "HostClasses"
     }
   ],
   "schemes": [
@@ -716,6 +719,210 @@
           "Clusters"
         ]
       }
+    },
+    "/api/fulfillment/v1/host_classes": {
+      "get": {
+        "summary": "Retrieves the list of host classes.",
+        "operationId": "HostClasses_List",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostClassesListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "offset",
+            "description": "Index of the first result. If not specified the default value will be zero.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of results to be returned by the server. When not specified all the results will be returned. Note\nthat there may not be enough results to return, and that the server may decide, for performance reasons, to return\nless results than requested.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "filter",
+            "description": "Filter criteria.\n\nThe syntax of this parameter is similar to the syntax of the _where_ clause of a SQL statement, but using the names\nof the attributes of the host class instead of the names of the columns of a table. For example, in order to\nretrieve all the host classes with a title starting with `gpu` the value should be:\n\n    title like 'gpu%'\n\nIf this isn't provided, or if the value is empty, then all the host classes that the user has permission to see\nwill be returned.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "description": "Order criteria.\n\nThe syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the\nnames of the attributes of the host class instead of the names of the columns of a table. For example, in order to\nsort the templates descending by title the value should be:\n\n    name desc\n\nIf the parameter isn't provided, or if the value is empty, then the order of the results is undefined.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostClasses"
+        ]
+      },
+      "post": {
+        "summary": "Creates a new host class.",
+        "description": "This method isn't allowed for regular users, only for the system itself.",
+        "operationId": "HostClasses_Create",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1HostClass"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "object",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1HostClass"
+            }
+          }
+        ],
+        "tags": [
+          "HostClasses"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/host_classes/{id}": {
+      "get": {
+        "summary": "Retrieves the details of one specific host classes.",
+        "operationId": "HostClasses_Get",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1HostClass"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostClasses"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a host class.",
+        "description": "This method isn't allowed for regular users, only for the system itself.",
+        "operationId": "HostClasses_Delete",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostClassesDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostClasses"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/host_classes/{object.id}": {
+      "patch": {
+        "summary": "Updates an existint host class.",
+        "description": "This method isn't allowed for regular users, only for the system itself.",
+        "operationId": "HostClasses_Update",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1HostClass"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "object.id",
+            "description": "Unique identifier of the class.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "object",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "$ref": "#/definitions/v1Metadata",
+                  "description": "Metadata of the host class."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Human friendly short description of the host class, only a few words, suitable for displaying in one single\nline on a UI or CLI."
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Human friendly long description of the host class, using Markdown format."
+                }
+              },
+              "description": "Describes a set of hosts that share characteristics.\n\nFor example there could be a host class `acme_1tb` to describe the set of hosts manifactured by ACME and with 1 TiB\nof RAM, and another `ibm_mi300x` to describe the set of hosts manufactured IBM and with a MI300X GPU.\n\nThis is similar to the _instance type_ concept used by many cloud providers.\n\nThe detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field."
+            }
+          }
+        ],
+        "tags": [
+          "HostClasses"
+        ]
+      }
     }
   },
   "definitions": {
@@ -824,10 +1031,26 @@
         "CLUSTER_CONDITION_TYPE_UNSPECIFIED",
         "CLUSTER_CONDITION_TYPE_PROGRESSING",
         "CLUSTER_CONDITION_TYPE_READY",
-        "CLUSTER_CONDITION_TYPE_FAILED"
+        "CLUSTER_CONDITION_TYPE_FAILED",
+        "CLUSTER_CONDITION_TYPE_DEGRADED"
       ],
       "default": "CLUSTER_CONDITION_TYPE_UNSPECIFIED",
-      "description": "Types of conditions used to describe the status of cluster.\n\n - CLUSTER_CONDITION_TYPE_UNSPECIFIED: Unspecified indicates that the condition is unknown.\n\nThis will never be appear in the `spec.conditions` field of a cluster.\n - CLUSTER_CONDITION_TYPE_PROGRESSING: Indicates that the cluster isn't completely ready yet.\n\nCurrently there are no `reason` values defined.\n - CLUSTER_CONDITION_TYPE_READY: Indicates that the cluster is ready to use.\n\nCurrently there are no `reason` values defined.\n - CLUSTER_CONDITION_TYPE_FAILED: Indicates that the cluster is unusable.\n\nCurrently there are no `reason` values defined."
+      "description": "Types of conditions used to describe the status of cluster.\n\n - CLUSTER_CONDITION_TYPE_UNSPECIFIED: Unspecified indicates that the condition is unknown.\n\nThis will never be appear in the `spec.conditions` field of a cluster.\n - CLUSTER_CONDITION_TYPE_PROGRESSING: Indicates that the cluster isn't completely ready yet.\n\nCurrently there are no `reason` values defined.\n - CLUSTER_CONDITION_TYPE_READY: Indicates that the cluster is ready to use.\n\nCurrently there are no `reason` values defined.\n - CLUSTER_CONDITION_TYPE_FAILED: Indicates that the cluster is unusable.\n\nCurrently there are no `reason` values defined.\n - CLUSTER_CONDITION_TYPE_DEGRADED: Indicates that the cluster is degraded."
+    },
+    "v1ClusterNodeSet": {
+      "type": "object",
+      "properties": {
+        "host_class": {
+          "type": "string",
+          "description": "Identifier of the class of hosts that are part of the set.\n\nThe details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For\nexample, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:\n\n```http\nGET /api/fulfillment/v1/host_classes/acme_1tb\n```\n\nWhich will return something like this:\n\n```json\n{\n  \"id\": \"acme_1tb\",\n  \"title\": \"ACME server with 1 TiB of RAM and no GPU\",\n  \"description\": \"ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU.\"\n}\n```\n\nThis will be set by the system when the cluster is initially created, according to the template selected by the\nuser.\n\nThe user will not have permission to change this field."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes of the set."
+        }
+      },
+      "description": "Defines a set of nodes that are part of the cluster, all of them of the same class of host."
     },
     "v1ClusterOrder": {
       "type": "object",
@@ -990,7 +1213,16 @@
     },
     "v1ClusterSpec": {
       "type": "object",
-      "description": "The spec contains the details of a cluster as desired by the user.\n\nNote that currently this is empty because there are no properties of the cluster that can be modified by the user."
+      "properties": {
+        "node_sets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1ClusterNodeSet"
+          },
+          "description": "Desired node sets of the cluster.\n\nThis will be automatically set by the system when the cluster is initially created, according to the template\nselected by the user, and can be later modified to change the size.\n\nThe key of the map is the unique identifier of the node set for this cluster.\n\nFor example, a cluster created with two different node sets, one for nodes without GPUs and another for nodes with\nGPUs could be represented like this:\n\n```json\n{\n  \"id\": \"123\",\n  \"spec\": {\n    \"node_sets\": {\n      \"compute\": {\n        \"host_class\": \"acme_1tb\",\n        \"size\": 3\n      },\n      \"gpu\": {\n        \"host_class\": \"acme_1tb_h100\",\n        \"size\": 3\n      }\n    }\n  },\n  \"status\": {\n    \"state\": \"CLUSTER_STATE_READY\",\n    \"node_sets\": {\n      \"compute\": {\n        \"host_class\": \"acme_1tb\",\n        \"size\": 3\n      },\n      \"gpu\": {\n        \"host_class\": \"acme_1tb_h100\",\n        \"size\": 3\n      }\n    }\n  }\n}\n```\n\nThe user will not be allowed to change the `host_class` field.\n\nThe user will not be allowed to remove existing node sets, or add new node sets.\n\nThe user will be allowed to update `size` field.\n\nIf at any time the system can't allocate the number of nodes requested by the user, because of permissions, quota,\navailability of resources or system errors, the cluster will be marked as degraded, and the details will be in the\n`DEGRADED` condition."
+        }
+      },
+      "description": "The spec contains the details of a cluster as desired by the user."
     },
     "v1ClusterState": {
       "type": "string",
@@ -1025,6 +1257,13 @@
         "console_url": {
           "type": "string",
           "description": "URL of the console of the cluster.\n\nThis will be empty if the cluster isn't ready or the console isn't enabled."
+        },
+        "node_sets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1ClusterNodeSet"
+          },
+          "description": "Current node sets of the cluster.\n\nThis is the current status of the node sets. It will be different to `spec.node_sets` when there is a change that\nis in progress, or if the system can't apply the changes requested by the user.\n\nThe key of the map is the unique identifier of the node set for this cluster."
         }
       },
       "description": "The status contains the details of the cluster provided by the system."
@@ -1248,6 +1487,78 @@
       "properties": {
         "event": {
           "$ref": "#/definitions/v1Event"
+        }
+      }
+    },
+    "v1HostClass": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the class."
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1Metadata",
+          "description": "Metadata of the host class."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human friendly short description of the host class, only a few words, suitable for displaying in one single\nline on a UI or CLI."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human friendly long description of the host class, using Markdown format."
+        }
+      },
+      "description": "Describes a set of hosts that share characteristics.\n\nFor example there could be a host class `acme_1tb` to describe the set of hosts manifactured by ACME and with 1 TiB\nof RAM, and another `ibm_mi300x` to describe the set of hosts manufactured IBM and with a MI300X GPU.\n\nThis is similar to the _instance type_ concept used by many cloud providers.\n\nThe detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field."
+    },
+    "v1HostClassesCreateResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1HostClass"
+        }
+      }
+    },
+    "v1HostClassesDeleteResponse": {
+      "type": "object"
+    },
+    "v1HostClassesGetResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1HostClass"
+        }
+      }
+    },
+    "v1HostClassesListResponse": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter\nof the request if there are not enough items, or of the system decides that returning that number of items isn't\nfeasible or convenient for performance reasons."
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items of the collection that match the search criteria, regardless of the number of results\nrequested with the `limit` parameter."
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HostClass"
+          },
+          "description": "List of results."
+        }
+      }
+    },
+    "v1HostClassesUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1HostClass"
         }
       }
     },

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -15,6 +15,7 @@ tags:
 - name: ClusterOrders
 - name: ClusterTemplates
 - name: Clusters
+- name: HostClasses
 paths:
   /api/events/v1/events:
     get:
@@ -710,6 +711,202 @@ paths:
               schema:
                 $ref: "#/components/schemas/rpcStatus"
       x-codegen-request-body-name: object
+  /api/fulfillment/v1/host_classes:
+    get:
+      tags:
+      - HostClasses
+      summary: Retrieves the list of host classes.
+      operationId: HostClasses_List
+      parameters:
+      - name: offset
+        in: query
+        description: Index of the first result. If not specified the default value
+          will be zero.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        description: |-
+          Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+          that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+          less results than requested.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        description: |-
+          Filter criteria.
+
+          The syntax of this parameter is similar to the syntax of the _where_ clause of a SQL statement, but using the names
+          of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+          retrieve all the host classes with a title starting with `gpu` the value should be:
+
+              title like 'gpu%'
+
+          If this isn't provided, or if the value is empty, then all the host classes that the user has permission to see
+          will be returned.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: order
+        in: query
+        description: |-
+          Order criteria.
+
+          The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+          names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+          sort the templates descending by title the value should be:
+
+              name desc
+
+          If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostClassesListResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+    post:
+      tags:
+      - HostClasses
+      summary: Creates a new host class.
+      description: "This method isn't allowed for regular users, only for the system\
+        \ itself."
+      operationId: HostClasses_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/v1HostClass"
+        required: true
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostClass"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+      x-codegen-request-body-name: object
+  /api/fulfillment/v1/host_classes/{id}:
+    get:
+      tags:
+      - HostClasses
+      summary: Retrieves the details of one specific host classes.
+      operationId: HostClasses_Get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostClass"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+    delete:
+      tags:
+      - HostClasses
+      summary: Delete a host class.
+      description: "This method isn't allowed for regular users, only for the system\
+        \ itself."
+      operationId: HostClasses_Delete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostClassesDeleteResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/host_classes/{object.id}:
+    patch:
+      tags:
+      - HostClasses
+      summary: Updates an existint host class.
+      description: "This method isn't allowed for regular users, only for the system\
+        \ itself."
+      operationId: HostClasses_Update
+      parameters:
+      - name: object.id
+        in: path
+        description: Unique identifier of the class.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/host_classes_object_id_body"
+        required: true
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostClass"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+      x-codegen-request-body-name: object
 components:
   schemas:
     apiHttpBody:
@@ -968,12 +1165,49 @@ components:
          - CLUSTER_CONDITION_TYPE_FAILED: Indicates that the cluster is unusable.
 
         Currently there are no `reason` values defined.
+         - CLUSTER_CONDITION_TYPE_DEGRADED: Indicates that the cluster is degraded.
       default: CLUSTER_CONDITION_TYPE_UNSPECIFIED
       enum:
       - CLUSTER_CONDITION_TYPE_UNSPECIFIED
       - CLUSTER_CONDITION_TYPE_PROGRESSING
       - CLUSTER_CONDITION_TYPE_READY
       - CLUSTER_CONDITION_TYPE_FAILED
+      - CLUSTER_CONDITION_TYPE_DEGRADED
+    v1ClusterNodeSet:
+      type: object
+      properties:
+        host_class:
+          type: string
+          description: |-
+            Identifier of the class of hosts that are part of the set.
+
+            The details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For
+            example, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:
+
+            ```http
+            GET /api/fulfillment/v1/host_classes/acme_1tb
+            ```
+
+            Which will return something like this:
+
+            ```json
+            {
+              "id": "acme_1tb",
+              "title": "ACME server with 1 TiB of RAM and no GPU",
+              "description": "ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU."
+            }
+            ```
+
+            This will be set by the system when the cluster is initially created, according to the template selected by the
+            user.
+
+            The user will not have permission to change this field.
+        size:
+          type: integer
+          description: Number of nodes of the set.
+          format: int32
+      description: "Defines a set of nodes that are part of the cluster, all of them\
+        \ of the same class of host."
     v1ClusterOrder:
       type: object
       properties:
@@ -1215,10 +1449,63 @@ components:
           $ref: "#/components/schemas/v1ClusterOrder"
     v1ClusterSpec:
       type: object
-      description: |-
-        The spec contains the details of a cluster as desired by the user.
+      properties:
+        node_sets:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/v1ClusterNodeSet"
+          description: |-
+            Desired node sets of the cluster.
 
-        Note that currently this is empty because there are no properties of the cluster that can be modified by the user.
+            This will be automatically set by the system when the cluster is initially created, according to the template
+            selected by the user, and can be later modified to change the size.
+
+            The key of the map is the unique identifier of the node set for this cluster.
+
+            For example, a cluster created with two different node sets, one for nodes without GPUs and another for nodes with
+            GPUs could be represented like this:
+
+            ```json
+            {
+              "id": "123",
+              "spec": {
+                "node_sets": {
+                  "compute": {
+                    "host_class": "acme_1tb",
+                    "size": 3
+                  },
+                  "gpu": {
+                    "host_class": "acme_1tb_h100",
+                    "size": 3
+                  }
+                }
+              },
+              "status": {
+                "state": "CLUSTER_STATE_READY",
+                "node_sets": {
+                  "compute": {
+                    "host_class": "acme_1tb",
+                    "size": 3
+                  },
+                  "gpu": {
+                    "host_class": "acme_1tb_h100",
+                    "size": 3
+                  }
+                }
+              }
+            }
+            ```
+
+            The user will not be allowed to change the `host_class` field.
+
+            The user will not be allowed to remove existing node sets, or add new node sets.
+
+            The user will be allowed to update `size` field.
+
+            If at any time the system can't allocate the number of nodes requested by the user, because of permissions, quota,
+            availability of resources or system errors, the cluster will be marked as degraded, and the details will be in the
+            `DEGRADED` condition.
+      description: The spec contains the details of a cluster as desired by the user.
     v1ClusterState:
       type: string
       description: |-
@@ -1292,6 +1579,17 @@ components:
             URL of the console of the cluster.
 
             This will be empty if the cluster isn't ready or the console isn't enabled.
+        node_sets:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/v1ClusterNodeSet"
+          description: |-
+            Current node sets of the cluster.
+
+            This is the current status of the node sets. It will be different to `spec.node_sets` when there is a change that
+            is in progress, or if the system can't apply the changes requested by the user.
+
+            The key of the map is the unique identifier of the node set for this cluster.
       description: The status contains the details of the cluster provided by the
         system.
     v1ClusterTemplate:
@@ -1510,6 +1808,70 @@ components:
       properties:
         event:
           $ref: "#/components/schemas/v1Event"
+    v1HostClass:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the class.
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        title:
+          type: string
+          description: |-
+            Human friendly short description of the host class, only a few words, suitable for displaying in one single
+            line on a UI or CLI.
+        description:
+          type: string
+          description: "Human friendly long description of the host class, using Markdown\
+            \ format."
+      description: |-
+        Describes a set of hosts that share characteristics.
+
+        For example there could be a host class `acme_1tb` to describe the set of hosts manifactured by ACME and with 1 TiB
+        of RAM, and another `ibm_mi300x` to describe the set of hosts manufactured IBM and with a MI300X GPU.
+
+        This is similar to the _instance type_ concept used by many cloud providers.
+
+        The detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field.
+    v1HostClassesCreateResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1HostClass"
+    v1HostClassesDeleteResponse:
+      type: object
+    v1HostClassesGetResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1HostClass"
+    v1HostClassesListResponse:
+      type: object
+      properties:
+        size:
+          type: integer
+          description: |-
+            Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+            of the request if there are not enough items, or of the system decides that returning that number of items isn't
+            feasible or convenient for performance reasons.
+          format: int32
+        total:
+          type: integer
+          description: |-
+            Total number of items of the collection that match the search criteria, regardless of the number of results
+            requested with the `limit` parameter.
+          format: int32
+        items:
+          type: array
+          description: List of results.
+          items:
+            $ref: "#/components/schemas/v1HostClass"
+    v1HostClassesUpdateResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1HostClass"
     v1Metadata:
       type: object
       properties:
@@ -1582,4 +1944,27 @@ components:
 
         The `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of
         the cluster, is provided by the system and can't be modified by the user.
+    host_classes_object_id_body:
+      type: object
+      properties:
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        title:
+          type: string
+          description: |-
+            Human friendly short description of the host class, only a few words, suitable for displaying in one single
+            line on a UI or CLI.
+        description:
+          type: string
+          description: "Human friendly long description of the host class, using Markdown\
+            \ format."
+      description: |-
+        Describes a set of hosts that share characteristics.
+
+        For example there could be a host class `acme_1tb` to describe the set of hosts manifactured by ACME and with 1 TiB
+        of RAM, and another `ibm_mi300x` to describe the set of hosts manufactured IBM and with a MI300X GPU.
+
+        This is similar to the _instance type_ concept used by many cloud providers.
+
+        The detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field.
 x-original-swagger-version: "2.0"

--- a/proto/fulfillment/v1/cluster_type.proto
+++ b/proto/fulfillment/v1/cluster_type.proto
@@ -33,9 +33,59 @@ message Cluster {
 }
 
 // The spec contains the details of a cluster as desired by the user.
-//
-// Note that currently this is empty because there are no properties of the cluster that can be modified by the user.
-message ClusterSpec {}
+message ClusterSpec {
+  // Desired node sets of the cluster.
+  //
+  // This will be automatically set by the system when the cluster is initially created, according to the template
+  // selected by the user, and can be later modified to change the size.
+  //
+  // The key of the map is the unique identifier of the node set for this cluster.
+  //
+  // For example, a cluster created with two different node sets, one for nodes without GPUs and another for nodes with
+  // GPUs could be represented like this:
+  //
+  // ```json
+  // {
+  //   "id": "123",
+  //   "spec": {
+  //     "node_sets": {
+  //       "compute": {
+  //         "host_class": "acme_1tb",
+  //         "size": 3
+  //       },
+  //       "gpu": {
+  //         "host_class": "acme_1tb_h100",
+  //         "size": 3
+  //       }
+  //     }
+  //   },
+  //   "status": {
+  //     "state": "CLUSTER_STATE_READY",
+  //     "node_sets": {
+  //       "compute": {
+  //         "host_class": "acme_1tb",
+  //         "size": 3
+  //       },
+  //       "gpu": {
+  //         "host_class": "acme_1tb_h100",
+  //         "size": 3
+  //       }
+  //     }
+  //   }
+  // }
+  // ```
+  //
+  // The user will not be allowed to change the `host_class` field.
+  //
+  // The user will not be allowed to remove existing node sets, or add new node sets.
+  //
+  // The user will be allowed to update `size` field.
+  //
+  // If at any time the system can't allocate the number of nodes requested by the user, because of permissions, quota,
+  // availability of resources or system errors, the cluster will be marked as degraded, and the details will be in the
+  // `DEGRADED` condition.
+  map<string, ClusterNodeSet> node_sets = 1;
+}
 
 // The status contains the details of the cluster provided by the system.
 message ClusterStatus {
@@ -89,6 +139,14 @@ message ClusterStatus {
   //
   // This will be empty if the cluster isn't ready or the console isn't enabled.
   string console_url = 4;
+
+  // Current node sets of the cluster.
+  //
+  // This is the current status of the node sets. It will be different to `spec.node_sets` when there is a change that
+  // is in progress, or if the system can't apply the changes requested by the user.
+  //
+  // The key of the map is the unique identifier of the node set for this cluster.
+  map<string, ClusterNodeSet> node_sets = 5;
 }
 
 // Represents the overall state of a cluster.
@@ -149,4 +207,38 @@ enum ClusterConditionType {
   //
   // Currently there are no `reason` values defined.
   CLUSTER_CONDITION_TYPE_FAILED = 3;
+
+  // Indicates that the cluster is degraded.
+  CLUSTER_CONDITION_TYPE_DEGRADED = 4;
+}
+
+// Defines a set of nodes that are part of the cluster, all of them of the same class of host.
+message ClusterNodeSet {
+  // Identifier of the class of hosts that are part of the set.
+  //
+  // The details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For
+  // example, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:
+  //
+  // ```http
+  // GET /api/fulfillment/v1/host_classes/acme_1tb
+  // ```
+  //
+  // Which will return something like this:
+  //
+  // ```json
+  // {
+  //   "id": "acme_1tb",
+  //   "title": "ACME server with 1 TiB of RAM and no GPU",
+  //   "description": "ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU."
+  // }
+  // ```
+  //
+  // This will be set by the system when the cluster is initially created, according to the template selected by the
+  // user.
+  //
+  // The user will not have permission to change this field.
+  string host_class = 1;
+
+  // Number of nodes of the set.
+  int32 size = 2;
 }

--- a/proto/fulfillment/v1/host_class_type.proto
+++ b/proto/fulfillment/v1/host_class_type.proto
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "shared/v1/metadata_type.proto";
+
+// Describes a set of hosts that share characteristics.
+//
+// For example there could be a host class `acme_1tb` to describe the set of hosts manifactured by ACME and with 1 TiB
+// of RAM, and another `ibm_mi300x` to describe the set of hosts manufactured IBM and with a MI300X GPU.
+//
+// This is similar to the _instance type_ concept used by many cloud providers.
+//
+// The detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field.
+message HostClass {
+  // Unique identifier of the class.
+  string id = 1;
+
+  // Metadata of the host class.
+  shared.v1.Metadata metadata = 2;
+
+  // Human friendly short description of the host class, only a few words, suitable for displaying in one single
+  // line on a UI or CLI.
+  string title = 3;
+
+  // Human friendly long description of the host class, using Markdown format.
+  string description = 4;
+}

--- a/proto/fulfillment/v1/host_classes_service.proto
+++ b/proto/fulfillment/v1/host_classes_service.proto
@@ -1,0 +1,142 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "fulfillment/v1/host_class_type.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/field_mask.proto";
+
+message HostClassesListRequest {
+  // Index of the first result. If not specified the default value will be zero.
+  optional int32 offset = 1;
+
+  // Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+  // that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+  // less results than requested.
+  optional int32 limit = 2;
+
+  // Filter criteria.
+  //
+  // The syntax of this parameter is similar to the syntax of the _where_ clause of a SQL statement, but using the names
+  // of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+  // retrieve all the host classes with a title starting with `gpu` the value should be:
+  //
+  //     title like 'gpu%'
+  //
+  // If this isn't provided, or if the value is empty, then all the host classes that the user has permission to see
+  // will be returned.
+  optional string filter = 3;
+
+  // Order criteria.
+  //
+  // The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+  // names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+  // sort the templates descending by title the value should be:
+  //
+  //     name desc
+  //
+  // If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+  optional string order = 4;
+}
+
+message HostClassesListResponse {
+  // Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+  // of the request if there are not enough items, or of the system decides that returning that number of items isn't
+  // feasible or convenient for performance reasons.
+  optional int32 size = 3;
+
+  // Total number of items of the collection that match the search criteria, regardless of the number of results
+  // requested with the `limit` parameter.
+  optional int32 total = 4;
+
+  // List of results.
+  repeated HostClass items = 5;
+}
+
+message HostClassesGetRequest {
+  string id = 1;
+}
+
+message HostClassesGetResponse {
+  HostClass object = 1;
+}
+
+message HostClassesCreateRequest {
+  HostClass object = 1;
+}
+
+message HostClassesCreateResponse {
+  HostClass object = 1;
+}
+
+message HostClassesUpdateRequest {
+  HostClass object = 1;
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message HostClassesUpdateResponse {
+  HostClass object = 1;
+}
+
+message HostClassesDeleteRequest {
+  string id = 1;
+}
+
+message HostClassesDeleteResponse {}
+
+service HostClasses {
+  // Retrieves the list of host classes.
+  rpc List(HostClassesListRequest) returns (HostClassesListResponse) {
+    option (google.api.http) = {get: "/api/fulfillment/v1/host_classes"};
+  }
+
+  // Retrieves the details of one specific host classes.
+  rpc Get(HostClassesGetRequest) returns (HostClassesGetResponse) {
+    option (google.api.http) = {
+      get: "/api/fulfillment/v1/host_classes/{id}"
+      response_body: "object"
+    };
+  }
+
+  // Creates a new host class.
+  //
+  // This method isn't allowed for regular users, only for the system itself.
+  rpc Create(HostClassesCreateRequest) returns (HostClassesCreateResponse) {
+    option (google.api.http) = {
+      post: "/api/fulfillment/v1/host_classes"
+      body: "object"
+      response_body: "object"
+    };
+  }
+
+  // Updates an existint host class.
+  //
+  // This method isn't allowed for regular users, only for the system itself.
+  rpc Update(HostClassesUpdateRequest) returns (HostClassesUpdateResponse) {
+    option (google.api.http) = {
+      patch: "/api/fulfillment/v1/host_classes/{object.id}"
+      body: "object"
+      response_body: "object"
+    };
+  }
+
+  // Delete a host class.
+  //
+  // This method isn't allowed for regular users, only for the system itself.
+  rpc Delete(HostClassesDeleteRequest) returns (HostClassesDeleteResponse) {
+    option (google.api.http) = {delete: "/api/fulfillment/v1/host_classes/{id}"};
+  }
+}


### PR DESCRIPTION
This patch adds to the `Cluster` type a new `node_sets` field to describe the sets of nodes that are part of the cluster, and to allow the user to change their size.

For example, a cluster with two node sets, one of them containing hosts with GPUs and another without could be represented like this:

```json
{
  "id": "123",
  "spec": {
    "node_sets": {
      "compute": {
        "class": "acme_1tb",
        "size": 3
      },
      "gpu": {
        "class": "acme_1tb_h100",
        "size": 1
      }
    }
  },
  "status": {
    "state": "CLUSTER_STATE_READY",
    "node_sets": {
      "compute": {
        "class": "acme_1tb",
        "size": 3
      },
      "gpu": {
        "class": "acme_1tb_h100",
        "size": 1
      }
    }
  }
}
```

The user will be able to scale each node set updating the `size` field of the `spec`.

The user will not have permission to edit any other field, or to add or remove node sets.

If the system is not able to resize the node set as requested it will set the `DEGRADED` condition to `true`, and will indicate the reason in the `message` field.

In order to provide information about the values of the `class` field of the node set the API will also have a new `HostClass` type and a `HostClases` service.

Related: https://github.com/innabox/issues/issues/99