### PR TITLE
Add initial node sets to cluster template

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -477,6 +477,13 @@
                     "$ref": "#/definitions/v1ClusterTemplateParameterDefinition"
                   },
                   "description": "Definitions of the parameters that can be used to customize the template.\n\nNote that these are only the *definitions* of the parameters, not the actual values. The actual values are in the\n`spec.template_parameters` field of the cluster order."
+                },
+                "node_sets": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/v1ClusterTemplateNodeSet"
+                  },
+                  "description": "Initial node sets of the cluster."
                 }
               },
               "description": "A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these\ntemplates: the system provides a collection of them, and the user chooses one."
@@ -1293,9 +1300,31 @@
             "$ref": "#/definitions/v1ClusterTemplateParameterDefinition"
           },
           "description": "Definitions of the parameters that can be used to customize the template.\n\nNote that these are only the *definitions* of the parameters, not the actual values. The actual values are in the\n`spec.template_parameters` field of the cluster order."
+        },
+        "node_sets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1ClusterTemplateNodeSet"
+          },
+          "description": "Initial node sets of the cluster."
         }
       },
       "description": "A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these\ntemplates: the system provides a collection of them, and the user chooses one."
+    },
+    "v1ClusterTemplateNodeSet": {
+      "type": "object",
+      "properties": {
+        "host_class": {
+          "type": "string",
+          "description": "Identifier of the class of hosts that are part of the set."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of nodes of the set."
+        }
+      },
+      "description": "Defines a set of nodes that will be part of cluster, all of them of the same class of host."
     },
     "v1ClusterTemplateParameterDefinition": {
       "type": "object",

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -1618,9 +1618,26 @@ components:
             `spec.template_parameters` field of the cluster order.
           items:
             $ref: "#/components/schemas/v1ClusterTemplateParameterDefinition"
+        node_sets:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/v1ClusterTemplateNodeSet"
+          description: Initial node sets of the cluster.
       description: |-
         A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these
         templates: the system provides a collection of them, and the user chooses one.
+    v1ClusterTemplateNodeSet:
+      type: object
+      properties:
+        host_class:
+          type: string
+          description: Identifier of the class of hosts that are part of the set.
+        size:
+          type: integer
+          description: Number of nodes of the set.
+          format: int32
+      description: "Defines a set of nodes that will be part of cluster, all of them\
+        \ of the same class of host."
     v1ClusterTemplateParameterDefinition:
       type: object
       properties:
@@ -1927,6 +1944,11 @@ components:
             `spec.template_parameters` field of the cluster order.
           items:
             $ref: "#/components/schemas/v1ClusterTemplateParameterDefinition"
+        node_sets:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/v1ClusterTemplateNodeSet"
+          description: Initial node sets of the cluster.
       description: |-
         A cluster template defines a type of cluster that can be ordered by the user. Note that the user doesn't create these
         templates: the system provides a collection of them, and the user chooses one.

--- a/proto/fulfillment/v1/cluster_template_type.proto
+++ b/proto/fulfillment/v1/cluster_template_type.proto
@@ -38,6 +38,9 @@ message ClusterTemplate {
   // Note that these are only the *definitions* of the parameters, not the actual values. The actual values are in the
   // `spec.template_parameters` field of the cluster order.
   repeated ClusterTemplateParameterDefinition parameters = 5;
+
+  // Initial node sets of the cluster.
+  map<string, ClusterTemplateNodeSet> node_sets = 6;
 }
 
 // Contains type and documentation of a template parameter.
@@ -87,4 +90,13 @@ message ClusterTemplateParameterDefinition {
 
   // Default value for optional parameters.
   google.protobuf.Any default = 6;
+}
+
+// Defines a set of nodes that will be part of cluster, all of them of the same class of host.
+message ClusterTemplateNodeSet {
+  // Identifier of the class of hosts that are part of the set.
+  string host_class = 1;
+
+  // Number of nodes of the set.
+  int32 size = 2;
 }


### PR DESCRIPTION
This patch adds to cluster templates a new `node_sets` field that defines the node sets that will be initially part of clusters created with this template.