### PR TITLE
Add method to get cluster admin password

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -638,8 +638,40 @@
     "/api/fulfillment/v1/clusters/{id}/kubeconfig": {
       "get": {
         "summary": "Returns the admin Kubeconfig of the cluster.",
-        "description": "This is intended for use with HTTP and returns the YAML text of the Kubeconfig directly using the content type\n`application/yaml`.\n\nbuf:lint:ignore RPC_RESPONSE_STANDARD_NAME",
+        "description": "This is intended for use with HTTP and returns the YAML text of the Kubeconfig directly using the content type\n`application/yaml`.\n\nbuf:lint:ignore RPC_RESPONSE_STANDARD_NAME\nbuf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE",
         "operationId": "Clusters_GetKubeconfigViaHttp",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiHttpBody"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Clusters"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/clusters/{id}/password": {
+      "get": {
+        "summary": "Returns the admin password of the cluster.",
+        "description": "This is intended for use with HTTP and returns the YAML text of the password directly using the content type\n`text/plain`.\n\nbuf:lint:ignore RPC_RESPONSE_STANDARD_NAME\nbuf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE",
+        "operationId": "Clusters_GetPasswordViaHttp",
         "responses": {
           "200": {
             "description": "A successful response.",
@@ -1392,6 +1424,14 @@
       "type": "object",
       "properties": {
         "kubeconfig": {
+          "type": "string"
+        }
+      }
+    },
+    "v1ClustersGetPasswordResponse": {
+      "type": "object",
+      "properties": {
+        "password": {
           "type": "string"
         }
       }

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -634,7 +634,41 @@ paths:
         `application/yaml`.
 
         buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+        buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
       operationId: Clusters_GetKubeconfigViaHttp
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/apiHttpBody"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/clusters/{id}/password:
+    get:
+      tags:
+      - Clusters
+      summary: Returns the admin password of the cluster.
+      description: |-
+        This is intended for use with HTTP and returns the YAML text of the password directly using the content type
+        `text/plain`.
+
+        buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+        buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+      operationId: Clusters_GetPasswordViaHttp
       parameters:
       - name: id
         in: path
@@ -1724,6 +1758,11 @@ components:
       type: object
       properties:
         kubeconfig:
+          type: string
+    v1ClustersGetPasswordResponse:
+      type: object
+      properties:
+        password:
           type: string
     v1ClustersGetResponse:
       type: object

--- a/proto/fulfillment/v1/clusters_service.proto
+++ b/proto/fulfillment/v1/clusters_service.proto
@@ -87,6 +87,18 @@ message ClustersGetKubeconfigViaHttpRequest {
   string id = 1;
 }
 
+message ClustersGetPasswordRequest {
+  string id = 1;
+}
+
+message ClustersGetPasswordResponse {
+  string password = 1;
+}
+
+message ClustersGetPasswordViaHttpRequest {
+  string id = 1;
+}
+
 message ClustersCreateRequest {
   Cluster object = 1;
 }
@@ -136,8 +148,26 @@ service Clusters {
   // `application/yaml`.
   //
   // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
   rpc GetKubeconfigViaHttp(ClustersGetKubeconfigViaHttpRequest) returns (google.api.HttpBody) {
     option (google.api.http) = {get: "/api/fulfillment/v1/clusters/{id}/kubeconfig"};
+  }
+
+  // Returns the admin password of the cluster.
+  //
+  // This intended for use with the gRPC protocol, and it isn't mapped to an HTTP endpoint. To retrieve the password
+  // via HTTP see the `ClustersGetPasswordViaHttp` method below.
+  rpc GetPassword(ClustersGetPasswordRequest) returns (ClustersGetPasswordResponse) {}
+
+  // Returns the admin password of the cluster.
+  //
+  // This is intended for use with HTTP and returns the YAML text of the password directly using the content type
+  // `text/plain`.
+  //
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  rpc GetPasswordViaHttp(ClustersGetPasswordViaHttpRequest) returns (google.api.HttpBody) {
+    option (google.api.http) = {get: "/api/fulfillment/v1/clusters/{id}/password"};
   }
 
   // Creates a new cluster.


### PR DESCRIPTION
This patch adds methods to get the admin password of a cluster. There are two variants:

- `/fulfillment.v1.Clusters/GetPassword` - This is intended for use via gRPC and isn't mapped to HTTP.

- `/fulfillment.v1.Clusters/GetPasswordViaHttp` - This is intended for use via HTTP and returns the password as plain text. It will be mapped to `/api/fulfillment/v1/clusters/{id}/password`.