### PR TITLE
Add `HostPool` and `Host` concepts

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -27,6 +27,12 @@
     },
     {
       "name": "HostClasses"
+    },
+    {
+      "name": "HostPools"
+    },
+    {
+      "name": "Hosts"
     }
   ],
   "schemes": [
@@ -962,6 +968,340 @@
           "HostClasses"
         ]
       }
+    },
+    "/api/fulfillment/v1/host_pools": {
+      "get": {
+        "summary": "Retrieves the list of host pools.",
+        "operationId": "HostPools_List",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostPoolsListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "offset",
+            "description": "Index of the first result. If not specified the default value will be zero.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of results to be returned by the server. When not specified all the results will be returned. Note\nthat there may not be enough results to return, and that the server may decide, for performance reasons, to return\nless results than requested.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "filter",
+            "description": "Filter criteria.\n\nThe syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the\nobject. For example, in order to retrieve all the orders with more than 3 hosts:\n\n    this.status.size \u003e 3\n\nIf this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be\nreturned.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "description": "Order criteria.\n\nThe syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the\nnames of the attributes of the host class instead of the names of the columns of a table. For example, in order to\nsort the templates descending by title the value should be:\n\n    name desc\n\nIf the parameter isn't provided, or if the value is empty, then the order of the results is undefined.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostPools"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/host_pools/{id}": {
+      "get": {
+        "summary": "Retrieves the details of one specific host pool.",
+        "operationId": "HostPools_Get",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1HostPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostPools"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a host pool.",
+        "operationId": "HostPools_Delete",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostPoolsDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "HostPools"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/host_pools/{object.id}": {
+      "patch": {
+        "summary": "Updates an existint host pool.",
+        "operationId": "HostPools_Update",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1HostPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "object.id",
+            "description": "Unique identifier of the pool.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "object",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "$ref": "#/definitions/v1Metadata"
+                },
+                "spec": {
+                  "$ref": "#/definitions/v1HostPoolSpec"
+                },
+                "status": {
+                  "$ref": "#/definitions/v1HostPoolStatus"
+                }
+              },
+              "description": "Contains the details of the pool.\n\nThe `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of\nthe pool, is provided by the system and can't be modified by the user."
+            }
+          }
+        ],
+        "tags": [
+          "HostPools"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/hosts": {
+      "get": {
+        "summary": "Retrieves the list of hosts.",
+        "operationId": "Hosts_List",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostsListResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "offset",
+            "description": "Index of the first result. If not specified the default value will be zero.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "limit",
+            "description": "Maximum number of results to be returned by the server. When not specified all the results will be returned. Note\nthat there may not be enough results to return, and that the server may decide, for performance reasons, to return\nless results than requested.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "filter",
+            "description": "Filter criteria.\n\nThe syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the\nobject. For example, in order to retrieve all the hosts that belong to pool `123`:\n\n    this.status.pool == '123'\n\nIf this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be\nreturned.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "description": "Order criteria.\n\nThe syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the\nnames of the attributes of the host class instead of the names of the columns of a table. For example, in order to\nsort the templates descending by title the value should be:\n\n    name desc\n\nIf the parameter isn't provided, or if the value is empty, then the order of the results is undefined.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Hosts"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/hosts/{id}": {
+      "get": {
+        "summary": "Retrieves the details of one specific host.",
+        "operationId": "Hosts_Get",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1Host"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Hosts"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a host.",
+        "operationId": "Hosts_Delete",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HostsDeleteResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Hosts"
+        ]
+      }
+    },
+    "/api/fulfillment/v1/hosts/{object.id}": {
+      "patch": {
+        "summary": "Updates an existint host.",
+        "operationId": "Hosts_Update",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/v1Host"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "object.id",
+            "description": "Unique identifier of the host.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "object",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "metadata": {
+                  "$ref": "#/definitions/v1Metadata"
+                },
+                "spec": {
+                  "$ref": "#/definitions/v1HostSpec"
+                },
+                "status": {
+                  "$ref": "#/definitions/v1HostStatus"
+                }
+              },
+              "description": "Contains the details of a specific host that is part of a pool of hosts."
+            }
+          }
+        ],
+        "tags": [
+          "Hosts"
+        ]
+      }
     }
   },
   "definitions": {
@@ -1559,6 +1899,25 @@
         }
       }
     },
+    "v1Host": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the host."
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1Metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/v1HostSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/v1HostStatus"
+        }
+      },
+      "description": "Contains the details of a specific host that is part of a pool of hosts."
+    },
     "v1HostClass": {
       "type": "object",
       "properties": {
@@ -1628,6 +1987,215 @@
       "properties": {
         "object": {
           "$ref": "#/definitions/v1HostClass"
+        }
+      }
+    },
+    "v1HostPool": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier of the pool."
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1Metadata"
+        },
+        "spec": {
+          "$ref": "#/definitions/v1HostPoolSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/v1HostPoolStatus"
+        }
+      },
+      "description": "Contains the details of the pool.\n\nThe `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of\nthe pool, is provided by the system and can't be modified by the user."
+    },
+    "v1HostPoolSpec": {
+      "type": "object",
+      "properties": {
+        "host_sets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HostSetSpec"
+          },
+          "description": "Desired host sets of the pool.\n\nFor example, a pool created with two different hosts sets, one for hosts without GPUs and another for hosts with\nGPUs could be be represented like this:\n\n```json\n{\n  \"spec\": {\n    \"host_sets\": [\n      {\n        \"host_class\": \"acme_1tb\",\n        \"size\": 3\n      },\n      {\n        \"host_class\": \"acme_1tb_h100\",\n        \"size\": 3\n      }\n    ]\n  }\n}\n```"
+        }
+      },
+      "description": "The spec contains the details of a pool as desired by the user."
+    },
+    "v1HostPoolState": {
+      "type": "string",
+      "enum": [
+        "HOST_POOL_STATE_UNSPECIFIED",
+        "HOST_POOL_STATE_PROGRESSING",
+        "HOST_POOL_STATE_READY",
+        "HOST_POOL_STATE_FAILED"
+      ],
+      "default": "HOST_POOL_STATE_UNSPECIFIED",
+      "description": "Represents the overall state of a pool.\n\n - HOST_POOL_STATE_UNSPECIFIED: Unspecified indicates that the state is unknown.\n - HOST_POOL_STATE_PROGRESSING: Indicates that the pool isn't ready yet.\n - HOST_POOL_STATE_READY: Indicates indicates that the pool is ready.\n - HOST_POOL_STATE_FAILED: Indicates indicates that the pool is unusable."
+    },
+    "v1HostPoolStatus": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/v1HostPoolState",
+          "description": "Indicates the overall state of the pool."
+        },
+        "host_sets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HostSetStatus"
+          },
+          "description": "Actual host sets of the pool.\n\nThis is the actual status of the hosts sets. It will be different to `spec.host_sets` when there is a change that\nis in progress, or if the system can't apply the changes requested by the user."
+        }
+      },
+      "description": "The status contains the details of the pool provided by the system."
+    },
+    "v1HostPoolsDeleteResponse": {
+      "type": "object"
+    },
+    "v1HostPoolsGetResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1HostPool"
+        }
+      }
+    },
+    "v1HostPoolsListResponse": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter\nof the request if there are not enough items, or of the system decides that returning that number of items isn't\nfeasible or convenient for performance reasons."
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items of the collection that match the search criteria, regardless of the number of results\nrequested with the `limit` parameter."
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HostPool"
+          },
+          "description": "List of results."
+        }
+      }
+    },
+    "v1HostPoolsUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1HostPool"
+        }
+      }
+    },
+    "v1HostSetSpec": {
+      "type": "object",
+      "properties": {
+        "host_class": {
+          "type": "string",
+          "description": "Identifier of the class of hosts.\n\nThe details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For\nexample, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:\n\n```http\nGET /api/fulfillment/v1/host_classes/acme_1tb\n```\n\nWhich will return something like this:\n\n```json\n{\n  \"id\": \"acme_1tb\",\n  \"title\": \"ACME server with 1 TiB of RAM and no GPU\",\n  \"description\": \"ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU.\"\n}\n```"
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Desired number of hosts of the set."
+        }
+      },
+      "description": "Desired set of hosts of the pool."
+    },
+    "v1HostSetStatus": {
+      "type": "object",
+      "properties": {
+        "host_class": {
+          "type": "string",
+          "description": "Identifier of the class of hosts."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual number of hosts of the set."
+        }
+      },
+      "description": "Actual set of hosts of the pool."
+    },
+    "v1HostSpec": {
+      "type": "object",
+      "description": "The spec contains the details of a host as desired by the user."
+    },
+    "v1HostState": {
+      "type": "string",
+      "enum": [
+        "HOST_STATE_UNSPECIFIED",
+        "HOST_STATE_PROGRESSING",
+        "HOST_STATE_READY",
+        "HOST_STATE_FAILED"
+      ],
+      "default": "HOST_STATE_UNSPECIFIED",
+      "description": "Represents the overall state of a host.\n\n - HOST_STATE_UNSPECIFIED: Unspecified indicates that the state is unknown.\n - HOST_STATE_PROGRESSING: Indicates that the host isn't ready yet.\n - HOST_STATE_READY: Indicates indicates that the host is ready.\n - HOST_STATE_FAILED: Indicates indicates that the host is unusable."
+    },
+    "v1HostStatus": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/v1HostState",
+          "description": "Indicates the overall state of the host."
+        },
+        "host_class": {
+          "type": "string",
+          "description": "Indicates the unique identifier of the host `HostClass` that this host belongs to."
+        },
+        "host_pool": {
+          "type": "string",
+          "description": "Indicates the unique identifier of the host `HostPool` that this host belongs to."
+        }
+      },
+      "description": "The status contains the details of the host provided by the system."
+    },
+    "v1HostsDeleteResponse": {
+      "type": "object"
+    },
+    "v1HostsGetResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1Host"
+        }
+      }
+    },
+    "v1HostsListResponse": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter\nof the request if there are not enough items, or of the system decides that returning that number of items isn't\nfeasible or convenient for performance reasons."
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of items of the collection that match the search criteria, regardless of the number of results\nrequested with the `limit` parameter."
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Host"
+          },
+          "description": "List of results."
+        }
+      }
+    },
+    "v1HostsUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/v1Host"
         }
       }
     },

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -16,6 +16,8 @@ tags:
 - name: ClusterTemplates
 - name: Clusters
 - name: HostClasses
+- name: HostPools
+- name: Hosts
 paths:
   /api/events/v1/events:
     get:
@@ -934,6 +936,334 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/v1HostClass"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+      x-codegen-request-body-name: object
+  /api/fulfillment/v1/host_pools:
+    get:
+      tags:
+      - HostPools
+      summary: Retrieves the list of host pools.
+      operationId: HostPools_List
+      parameters:
+      - name: offset
+        in: query
+        description: Index of the first result. If not specified the default value
+          will be zero.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        description: |-
+          Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+          that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+          less results than requested.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        description: |-
+          Filter criteria.
+
+          The syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the
+          object. For example, in order to retrieve all the orders with more than 3 hosts:
+
+              this.status.size > 3
+
+          If this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be
+          returned.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: order
+        in: query
+        description: |-
+          Order criteria.
+
+          The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+          names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+          sort the templates descending by title the value should be:
+
+              name desc
+
+          If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostPoolsListResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/host_pools/{id}:
+    get:
+      tags:
+      - HostPools
+      summary: Retrieves the details of one specific host pool.
+      operationId: HostPools_Get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostPool"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+    delete:
+      tags:
+      - HostPools
+      summary: Delete a host pool.
+      operationId: HostPools_Delete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostPoolsDeleteResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/host_pools/{object.id}:
+    patch:
+      tags:
+      - HostPools
+      summary: Updates an existint host pool.
+      operationId: HostPools_Update
+      parameters:
+      - name: object.id
+        in: path
+        description: Unique identifier of the pool.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/host_pools_object_id_body"
+        required: true
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostPool"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+      x-codegen-request-body-name: object
+  /api/fulfillment/v1/hosts:
+    get:
+      tags:
+      - Hosts
+      summary: Retrieves the list of hosts.
+      operationId: Hosts_List
+      parameters:
+      - name: offset
+        in: query
+        description: Index of the first result. If not specified the default value
+          will be zero.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        description: |-
+          Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+          that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+          less results than requested.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: filter
+        in: query
+        description: |-
+          Filter criteria.
+
+          The syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the
+          object. For example, in order to retrieve all the hosts that belong to pool `123`:
+
+              this.status.pool == '123'
+
+          If this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be
+          returned.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      - name: order
+        in: query
+        description: |-
+          Order criteria.
+
+          The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+          names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+          sort the templates descending by title the value should be:
+
+              name desc
+
+          If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostsListResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/hosts/{id}:
+    get:
+      tags:
+      - Hosts
+      summary: Retrieves the details of one specific host.
+      operationId: Hosts_Get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1Host"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+    delete:
+      tags:
+      - Hosts
+      summary: Delete a host.
+      operationId: Hosts_Delete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1HostsDeleteResponse"
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/rpcStatus"
+  /api/fulfillment/v1/hosts/{object.id}:
+    patch:
+      tags:
+      - Hosts
+      summary: Updates an existint host.
+      operationId: Hosts_Update
+      parameters:
+      - name: object.id
+        in: path
+        description: Unique identifier of the host.
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/hosts_object_id_body"
+        required: true
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/v1Host"
         default:
           description: An unexpected error response.
           content:
@@ -1864,6 +2194,20 @@ components:
       properties:
         event:
           $ref: "#/components/schemas/v1Event"
+    v1Host:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the host.
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        spec:
+          $ref: "#/components/schemas/v1HostSpec"
+        status:
+          $ref: "#/components/schemas/v1HostStatus"
+      description: Contains the details of a specific host that is part of a pool
+        of hosts.
     v1HostClass:
       type: object
       properties:
@@ -1928,6 +2272,221 @@ components:
       properties:
         object:
           $ref: "#/components/schemas/v1HostClass"
+    v1HostPool:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the pool.
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        spec:
+          $ref: "#/components/schemas/v1HostPoolSpec"
+        status:
+          $ref: "#/components/schemas/v1HostPoolStatus"
+      description: |-
+        Contains the details of the pool.
+
+        The `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of
+        the pool, is provided by the system and can't be modified by the user.
+    v1HostPoolSpec:
+      type: object
+      properties:
+        host_sets:
+          type: array
+          description: |-
+            Desired host sets of the pool.
+
+            For example, a pool created with two different hosts sets, one for hosts without GPUs and another for hosts with
+            GPUs could be be represented like this:
+
+            ```json
+            {
+              "spec": {
+                "host_sets": [
+                  {
+                    "host_class": "acme_1tb",
+                    "size": 3
+                  },
+                  {
+                    "host_class": "acme_1tb_h100",
+                    "size": 3
+                  }
+                ]
+              }
+            }
+            ```
+          items:
+            $ref: "#/components/schemas/v1HostSetSpec"
+      description: The spec contains the details of a pool as desired by the user.
+    v1HostPoolState:
+      type: string
+      description: |-
+        Represents the overall state of a pool.
+
+         - HOST_POOL_STATE_UNSPECIFIED: Unspecified indicates that the state is unknown.
+         - HOST_POOL_STATE_PROGRESSING: Indicates that the pool isn't ready yet.
+         - HOST_POOL_STATE_READY: Indicates indicates that the pool is ready.
+         - HOST_POOL_STATE_FAILED: Indicates indicates that the pool is unusable.
+      default: HOST_POOL_STATE_UNSPECIFIED
+      enum:
+      - HOST_POOL_STATE_UNSPECIFIED
+      - HOST_POOL_STATE_PROGRESSING
+      - HOST_POOL_STATE_READY
+      - HOST_POOL_STATE_FAILED
+    v1HostPoolStatus:
+      type: object
+      properties:
+        state:
+          $ref: "#/components/schemas/v1HostPoolState"
+        host_sets:
+          type: array
+          description: |-
+            Actual host sets of the pool.
+
+            This is the actual status of the hosts sets. It will be different to `spec.host_sets` when there is a change that
+            is in progress, or if the system can't apply the changes requested by the user.
+          items:
+            $ref: "#/components/schemas/v1HostSetStatus"
+      description: The status contains the details of the pool provided by the system.
+    v1HostPoolsDeleteResponse:
+      type: object
+    v1HostPoolsGetResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1HostPool"
+    v1HostPoolsListResponse:
+      type: object
+      properties:
+        size:
+          type: integer
+          description: |-
+            Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+            of the request if there are not enough items, or of the system decides that returning that number of items isn't
+            feasible or convenient for performance reasons.
+          format: int32
+        total:
+          type: integer
+          description: |-
+            Total number of items of the collection that match the search criteria, regardless of the number of results
+            requested with the `limit` parameter.
+          format: int32
+        items:
+          type: array
+          description: List of results.
+          items:
+            $ref: "#/components/schemas/v1HostPool"
+    v1HostPoolsUpdateResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1HostPool"
+    v1HostSetSpec:
+      type: object
+      properties:
+        host_class:
+          type: string
+          description: |-
+            Identifier of the class of hosts.
+
+            The details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For
+            example, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:
+
+            ```http
+            GET /api/fulfillment/v1/host_classes/acme_1tb
+            ```
+
+            Which will return something like this:
+
+            ```json
+            {
+              "id": "acme_1tb",
+              "title": "ACME server with 1 TiB of RAM and no GPU",
+              "description": "ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU."
+            }
+            ```
+        size:
+          type: integer
+          description: Desired number of hosts of the set.
+          format: int32
+      description: Desired set of hosts of the pool.
+    v1HostSetStatus:
+      type: object
+      properties:
+        host_class:
+          type: string
+          description: Identifier of the class of hosts.
+        size:
+          type: integer
+          description: Actual number of hosts of the set.
+          format: int32
+      description: Actual set of hosts of the pool.
+    v1HostSpec:
+      type: object
+      description: The spec contains the details of a host as desired by the user.
+    v1HostState:
+      type: string
+      description: |-
+        Represents the overall state of a host.
+
+         - HOST_STATE_UNSPECIFIED: Unspecified indicates that the state is unknown.
+         - HOST_STATE_PROGRESSING: Indicates that the host isn't ready yet.
+         - HOST_STATE_READY: Indicates indicates that the host is ready.
+         - HOST_STATE_FAILED: Indicates indicates that the host is unusable.
+      default: HOST_STATE_UNSPECIFIED
+      enum:
+      - HOST_STATE_UNSPECIFIED
+      - HOST_STATE_PROGRESSING
+      - HOST_STATE_READY
+      - HOST_STATE_FAILED
+    v1HostStatus:
+      type: object
+      properties:
+        state:
+          $ref: "#/components/schemas/v1HostState"
+        host_class:
+          type: string
+          description: Indicates the unique identifier of the host `HostClass` that
+            this host belongs to.
+        host_pool:
+          type: string
+          description: Indicates the unique identifier of the host `HostPool` that
+            this host belongs to.
+      description: The status contains the details of the host provided by the system.
+    v1HostsDeleteResponse:
+      type: object
+    v1HostsGetResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1Host"
+    v1HostsListResponse:
+      type: object
+      properties:
+        size:
+          type: integer
+          description: |-
+            Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+            of the request if there are not enough items, or of the system decides that returning that number of items isn't
+            feasible or convenient for performance reasons.
+          format: int32
+        total:
+          type: integer
+          description: |-
+            Total number of items of the collection that match the search criteria, regardless of the number of results
+            requested with the `limit` parameter.
+          format: int32
+        items:
+          type: array
+          description: List of results.
+          items:
+            $ref: "#/components/schemas/v1Host"
+    v1HostsUpdateResponse:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/v1Host"
     v1Metadata:
       type: object
       properties:
@@ -2028,4 +2587,29 @@ components:
         This is similar to the _instance type_ concept used by many cloud providers.
 
         The detailed chracteristics of the host (CPU, memory, GPU, etc) will be in the `description` field.
+    host_pools_object_id_body:
+      type: object
+      properties:
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        spec:
+          $ref: "#/components/schemas/v1HostPoolSpec"
+        status:
+          $ref: "#/components/schemas/v1HostPoolStatus"
+      description: |-
+        Contains the details of the pool.
+
+        The `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of
+        the pool, is provided by the system and can't be modified by the user.
+    hosts_object_id_body:
+      type: object
+      properties:
+        metadata:
+          $ref: "#/components/schemas/v1Metadata"
+        spec:
+          $ref: "#/components/schemas/v1HostSpec"
+        status:
+          $ref: "#/components/schemas/v1HostStatus"
+      description: Contains the details of a specific host that is part of a pool
+        of hosts.
 x-original-swagger-version: "2.0"

--- a/proto/fulfillment/v1/host_pool_type.proto
+++ b/proto/fulfillment/v1/host_pool_type.proto
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "shared/v1/metadata_type.proto";
+
+// Contains the details of the pool.
+//
+// The `spec` contains the desired details, and may be modified by the user. The `status` contains the current status of
+// the pool, is provided by the system and can't be modified by the user.
+message HostPool {
+  // Unique identifier of the pool.
+  string id = 1;
+
+  shared.v1.Metadata metadata = 2;
+  HostPoolSpec spec = 3;
+  HostPoolStatus status = 4;
+}
+
+// The spec contains the details of a pool as desired by the user.
+message HostPoolSpec {
+  // Desired host sets of the pool.
+  //
+  // For example, a pool created with two different hosts sets, one for hosts without GPUs and another for hosts with
+  // GPUs could be be represented like this:
+  //
+  // ```json
+  // {
+  //   "spec": {
+  //     "host_sets": [
+  //       {
+  //         "host_class": "acme_1tb",
+  //         "size": 3
+  //       },
+  //       {
+  //         "host_class": "acme_1tb_h100",
+  //         "size": 3
+  //       }
+  //     ]
+  //   }
+  // }
+  // ```
+  repeated HostSetSpec host_sets = 1;
+}
+
+// The status contains the details of the pool provided by the system.
+message HostPoolStatus {
+  // Indicates the overall state of the pool.
+  HostPoolState state = 1;
+
+  // Actual host sets of the pool.
+  //
+  // This is the actual status of the hosts sets. It will be different to `spec.host_sets` when there is a change that
+  // is in progress, or if the system can't apply the changes requested by the user.
+  repeated HostSetStatus host_sets = 2;
+}
+
+// Represents the overall state of a pool.
+enum HostPoolState {
+  // Unspecified indicates that the state is unknown.
+  HOST_POOL_STATE_UNSPECIFIED = 0;
+
+  // Indicates that the pool isn't ready yet.
+  HOST_POOL_STATE_PROGRESSING = 1;
+
+  // Indicates indicates that the pool is ready.
+  HOST_POOL_STATE_READY = 2;
+
+  // Indicates indicates that the pool is unusable.
+  HOST_POOL_STATE_FAILED = 3;
+}
+
+// Desired set of hosts of the pool.
+message HostSetSpec {
+  // Identifier of the class of hosts.
+  //
+  // The details of the host class can be obtained using the `List` and `Get` method of the `HostClasses` service. For
+  // example, to get the details of the `acme_1tb` host class using the HTTP+JSON version of the API:
+  //
+  // ```http
+  // GET /api/fulfillment/v1/host_classes/acme_1tb
+  // ```
+  //
+  // Which will return something like this:
+  //
+  // ```json
+  // {
+  //   "id": "acme_1tb",
+  //   "title": "ACME server with 1 TiB of RAM and no GPU",
+  //   "description": "ACME server model XYZ with 1 TiB of RAM, 2 Xeon 6 CPUS and no GPU."
+  // }
+  // ```
+  string host_class = 1;
+
+  // Desired number of hosts of the set.
+  int32 size = 2;
+}
+
+// Actual set of hosts of the pool.
+message HostSetStatus {
+  // Identifier of the class of hosts.
+  string host_class = 1;
+
+  // Actual number of hosts of the set.
+  int32 size = 2;
+}

--- a/proto/fulfillment/v1/host_pools_service.proto
+++ b/proto/fulfillment/v1/host_pools_service.proto
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "fulfillment/v1/host_pool_type.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/field_mask.proto";
+
+message HostPoolsListRequest {
+  // Index of the first result. If not specified the default value will be zero.
+  optional int32 offset = 1;
+
+  // Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+  // that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+  // less results than requested.
+  optional int32 limit = 2;
+
+  // Filter criteria.
+  //
+  // The syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the
+  // object. For example, in order to retrieve all the orders with more than 3 hosts:
+  //
+  //     this.status.size > 3
+  //
+  // If this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be
+  // returned.
+  optional string filter = 3;
+
+  // Order criteria.
+  //
+  // The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+  // names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+  // sort the templates descending by title the value should be:
+  //
+  //     name desc
+  //
+  // If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+  optional string order = 4;
+}
+
+message HostPoolsListResponse {
+  // Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+  // of the request if there are not enough items, or of the system decides that returning that number of items isn't
+  // feasible or convenient for performance reasons.
+  optional int32 size = 3;
+
+  // Total number of items of the collection that match the search criteria, regardless of the number of results
+  // requested with the `limit` parameter.
+  optional int32 total = 4;
+
+  // List of results.
+  repeated HostPool items = 5;
+}
+
+message HostPoolsGetRequest {
+  string id = 1;
+}
+
+message HostPoolsGetResponse {
+  HostPool object = 1;
+}
+
+message HostPoolsCreateRequest {
+  HostPool object = 1;
+}
+
+message HostPoolsCreateResponse {
+  HostPool object = 1;
+}
+
+message HostPoolsUpdateRequest {
+  HostPool object = 1;
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message HostPoolsUpdateResponse {
+  HostPool object = 1;
+}
+
+message HostPoolsDeleteRequest {
+  string id = 1;
+}
+
+message HostPoolsDeleteResponse {}
+
+service HostPools {
+  // Retrieves the list of host pools.
+  rpc List(HostPoolsListRequest) returns (HostPoolsListResponse) {
+    option (google.api.http) = {get: "/api/fulfillment/v1/host_pools"};
+  }
+
+  // Retrieves the details of one specific host pool.
+  rpc Get(HostPoolsGetRequest) returns (HostPoolsGetResponse) {
+    option (google.api.http) = {
+      get: "/api/fulfillment/v1/host_pools/{id}"
+      response_body: "object"
+    };
+  }
+
+  // Updates an existint host pool.
+  rpc Update(HostPoolsUpdateRequest) returns (HostPoolsUpdateResponse) {
+    option (google.api.http) = {
+      patch: "/api/fulfillment/v1/host_pools/{object.id}"
+      body: "object"
+      response_body: "object"
+    };
+  }
+
+  // Delete a host pool.
+  rpc Delete(HostPoolsDeleteRequest) returns (HostPoolsDeleteResponse) {
+    option (google.api.http) = {delete: "/api/fulfillment/v1/host_pools/{id}"};
+  }
+}

--- a/proto/fulfillment/v1/host_type.proto
+++ b/proto/fulfillment/v1/host_type.proto
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "shared/v1/metadata_type.proto";
+
+// Contains the details of a specific host that is part of a pool of hosts.
+message Host {
+  // Unique identifier of the host.
+  string id = 1;
+
+  shared.v1.Metadata metadata = 2;
+  HostSpec spec = 3;
+  HostStatus status = 4;
+}
+
+// The spec contains the details of a host as desired by the user.
+message HostSpec {}
+
+// The status contains the details of the host provided by the system.
+message HostStatus {
+  // Indicates the overall state of the host.
+  HostState state = 1;
+
+  // Indicates the unique identifier of the host `HostClass` that this host belongs to.
+  string host_class = 2;
+
+  // Indicates the unique identifier of the host `HostPool` that this host belongs to.
+  string host_pool = 3;
+}
+
+// Represents the overall state of a host.
+enum HostState {
+  // Unspecified indicates that the state is unknown.
+  HOST_STATE_UNSPECIFIED = 0;
+
+  // Indicates that the host isn't ready yet.
+  HOST_STATE_PROGRESSING = 1;
+
+  // Indicates indicates that the host is ready.
+  HOST_STATE_READY = 2;
+
+  // Indicates indicates that the host is unusable.
+  HOST_STATE_FAILED = 3;
+}

--- a/proto/fulfillment/v1/hosts_service.proto
+++ b/proto/fulfillment/v1/hosts_service.proto
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2025 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+
+syntax = "proto3";
+
+package fulfillment.v1;
+
+import "fulfillment/v1/host_type.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/field_mask.proto";
+
+message HostsListRequest {
+  // Index of the first result. If not specified the default value will be zero.
+  optional int32 offset = 1;
+
+  // Maximum number of results to be returned by the server. When not specified all the results will be returned. Note
+  // that there may not be enough results to return, and that the server may decide, for performance reasons, to return
+  // less results than requested.
+  optional int32 limit = 2;
+
+  // Filter criteria.
+  //
+  // The syntax of this parameter is a CEL expression using the `this` prefix for the names of the attributes of the
+  // object. For example, in order to retrieve all the hosts that belong to pool `123`:
+  //
+  //     this.status.pool == '123'
+  //
+  // If this isn't provided, or if the value is empty, then all the orders that the user has permission to see will be
+  // returned.
+  optional string filter = 3;
+
+  // Order criteria.
+  //
+  // The syntax of this parameter is similar to the syntax of the _order by_ clause of a SQL statement, but using the
+  // names of the attributes of the host class instead of the names of the columns of a table. For example, in order to
+  // sort the templates descending by title the value should be:
+  //
+  //     name desc
+  //
+  // If the parameter isn't provided, or if the value is empty, then the order of the results is undefined.
+  optional string order = 4;
+}
+
+message HostsListResponse {
+  // Actual number of items returned. Note that this may be smaller than the value requested in the `limit` parameter
+  // of the request if there are not enough items, or of the system decides that returning that number of items isn't
+  // feasible or convenient for performance reasons.
+  optional int32 size = 3;
+
+  // Total number of items of the collection that match the search criteria, regardless of the number of results
+  // requested with the `limit` parameter.
+  optional int32 total = 4;
+
+  // List of results.
+  repeated Host items = 5;
+}
+
+message HostsGetRequest {
+  string id = 1;
+}
+
+message HostsGetResponse {
+  Host object = 1;
+}
+
+message HostsCreateRequest {
+  Host object = 1;
+}
+
+message HostsCreateResponse {
+  Host object = 1;
+}
+
+message HostsUpdateRequest {
+  Host object = 1;
+  google.protobuf.FieldMask update_mask = 2;
+}
+
+message HostsUpdateResponse {
+  Host object = 1;
+}
+
+message HostsDeleteRequest {
+  string id = 1;
+}
+
+message HostsDeleteResponse {}
+
+service Hosts {
+  // Retrieves the list of hosts.
+  rpc List(HostsListRequest) returns (HostsListResponse) {
+    option (google.api.http) = {get: "/api/fulfillment/v1/hosts"};
+  }
+
+  // Retrieves the details of one specific host.
+  rpc Get(HostsGetRequest) returns (HostsGetResponse) {
+    option (google.api.http) = {
+      get: "/api/fulfillment/v1/hosts/{id}"
+      response_body: "object"
+    };
+  }
+
+  // Updates an existint host.
+  rpc Update(HostsUpdateRequest) returns (HostsUpdateResponse) {
+    option (google.api.http) = {
+      patch: "/api/fulfillment/v1/hosts/{object.id}"
+      body: "object"
+      response_body: "object"
+    };
+  }
+
+  // Delete a host.
+  rpc Delete(HostsDeleteRequest) returns (HostsDeleteResponse) {
+    option (google.api.http) = {delete: "/api/fulfillment/v1/hosts/{id}"};
+  }
+}


### PR DESCRIPTION
This patch adds the `HostPool` and `Host` concepts that will be the basis for the bare metal host provisioning feature.
The `HostPool` represents a pool of hosts, each containing potentially multiple sets of hosts. It will contain the fields that allow the user to modify the pool, or for example to change the number of hosts.

The `Host` represents a host that has been allocated and assigned to a pool. The `status.host_pool` field will indicate the pool that it belongs to.