### PR TITLE
Fix location of update mask for clusters

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -1151,9 +1151,6 @@
       "properties": {
         "object": {
           "$ref": "#/definitions/v1Cluster"
-        },
-        "update_mask": {
-          "type": "string"
         }
       }
     },

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -1408,8 +1408,6 @@ components:
       properties:
         object:
           $ref: "#/components/schemas/v1Cluster"
-        update_mask:
-          type: string
     v1ConditionStatus:
       type: string
       description: |2-

--- a/proto/fulfillment/v1/clusters_service.proto
+++ b/proto/fulfillment/v1/clusters_service.proto
@@ -109,11 +109,11 @@ message ClustersCreateResponse {
 
 message ClustersUpdateRequest {
   Cluster object = 1;
+  google.protobuf.FieldMask update_mask = 2;
 }
 
 message ClustersUpdateResponse {
   Cluster object = 1;
-  google.protobuf.FieldMask update_mask = 2;
 }
 
 message ClustersDeleteRequest {


### PR DESCRIPTION
Currently the `update_mask` field is in the response of the method that updates a cluster, but it should be in the request.