### PR TITLE
Add owner field to Metadata proto

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -1287,6 +1287,10 @@
           "type": "string",
           "format": "date-time",
           "description": "Time of deletion of the object."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Owner of the object."
         }
       },
       "description": "Metadata common to all kinds of objects."

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -1531,6 +1531,9 @@ components:
           type: string
           description: Time of deletion of the object.
           format: date-time
+        owner:
+          type: string
+          description: Owner of the object.
       description: Metadata common to all kinds of objects.
     Stream result of v1EventsWatchResponse:
       title: Stream result of v1EventsWatchResponse

--- a/proto/shared/v1/metadata_type.proto
+++ b/proto/shared/v1/metadata_type.proto
@@ -24,4 +24,7 @@ message Metadata {
 
   // Time of deletion of the object.
   google.protobuf.Timestamp deletion_timestamp = 2;
+
+  // Owner of the object.
+  string owner = 3;
 }


### PR DESCRIPTION
Adds a new string field 'owner' to the Metadata message to track object ownership.
