### PR TITLE
Add support for multiple owners

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -1288,9 +1288,12 @@
           "format": "date-time",
           "description": "Time of deletion of the object."
         },
-        "owner": {
-          "type": "string",
-          "description": "Owner of the object."
+        "owners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of the owners of the object."
         }
       },
       "description": "Metadata common to all kinds of objects."

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -1531,9 +1531,11 @@ components:
           type: string
           description: Time of deletion of the object.
           format: date-time
-        owner:
-          type: string
-          description: Owner of the object.
+        owners:
+          type: array
+          description: Names of the owners of the object.
+          items:
+            type: string
       description: Metadata common to all kinds of objects.
     Stream result of v1EventsWatchResponse:
       title: Stream result of v1EventsWatchResponse

--- a/proto/shared/v1/metadata_type.proto
+++ b/proto/shared/v1/metadata_type.proto
@@ -25,6 +25,6 @@ message Metadata {
   // Time of deletion of the object.
   google.protobuf.Timestamp deletion_timestamp = 2;
 
-  // Owner of the object.
-  string owner = 3;
+  // Names of the owners of the object.
+  repeated string owners = 3;
 }


### PR DESCRIPTION
This patch replaces the `metadata.owner` field by a repeated `metadata.owners` field, so that it will be possible to assign multiple owners to the same object.