### PR TITLE
Rename `owner` to `creator`

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -1702,12 +1702,12 @@
           "format": "date-time",
           "description": "Time of deletion of the object."
         },
-        "owners": {
+        "creators": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Names of the owners of the object."
+          "description": "Names of the creators of the object."
         }
       },
       "description": "Metadata common to all kinds of objects."

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -1936,9 +1936,9 @@ components:
           type: string
           description: Time of deletion of the object.
           format: date-time
-        owners:
+        creators:
           type: array
-          description: Names of the owners of the object.
+          description: Names of the creators of the object.
           items:
             type: string
       description: Metadata common to all kinds of objects.

--- a/proto/shared/v1/metadata_type.proto
+++ b/proto/shared/v1/metadata_type.proto
@@ -25,6 +25,6 @@ message Metadata {
   // Time of deletion of the object.
   google.protobuf.Timestamp deletion_timestamp = 2;
 
-  // Names of the owners of the object.
-  repeated string owners = 3;
+  // Names of the creators of the object.
+  repeated string creators = 3;
 }


### PR DESCRIPTION
We have decided that `creator` is better name to describe the user or group that initially created the object.