### PR TITLE
Fix names of generated OpenAPI stream results

### DIFF
--- a/openapi/v2/openapi.json
+++ b/openapi/v2/openapi.json
@@ -66,7 +66,7 @@
                   "$ref": "#/definitions/rpcStatus"
                 }
               },
-              "title": "Stream result of v1EventsWatchResponse"
+              "title": "v1EventsWatchResponseStreamResult"
             }
           },
           "default": {

--- a/openapi/v3/openapi.yaml
+++ b/openapi/v3/openapi.yaml
@@ -59,7 +59,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Stream result of v1EventsWatchResponse"
+                $ref: "#/components/schemas/v1EventsWatchResponseStreamResult"
         default:
           description: An unexpected error response.
           content:
@@ -3023,8 +3023,8 @@ components:
       properties:
         object:
           $ref: "#/components/schemas/v1VirtualMachine"
-    Stream result of v1EventsWatchResponse:
-      title: Stream result of v1EventsWatchResponse
+    v1EventsWatchResponseStreamResult:
+      title: v1EventsWatchResponseStreamResult
       type: object
       properties:
         result:


### PR DESCRIPTION
The tool that we use to generate OpenAPI specifications generates names for stream results with spaces, something like this:

```
    Stream result of v1EventsWatchResponse:
      title: Stream result of v1EventsWatchResponse
```

Some OpenAPI tools, like `oq`, don't accept those spaces. To address that this patch changes the code that generates the OpenAPI schemas so that it replaces `Stream result of ...` with `...StreamResult`.

Resolves: https://github.com/innabox/fulfillment-api/issues/45
Related: https://github.com/plutov/oq